### PR TITLE
Update FilesClient.cs

### DIFF
--- a/Egnyte.Api/Files/FilesClient.cs
+++ b/Egnyte.Api/Files/FilesClient.cs
@@ -181,7 +181,14 @@
             
             var serviceHandler = new ServiceHandler<string>(httpClient);
             var response = await serviceHandler.GetFileToDownload(httpRequest).ConfigureAwait(false);
-
+            
+            //Method did not throw an exception
+            if (response.Headers.ContainsKey("X-Mashery-Error-Code"))
+            {
+            string errormsg;
+            response.Headers.TryGetValue("X-Mashery-Error-Code",out errormsg);
+            throw new Exception(errormsg);
+            }
             return MapResponseToDownloadedFile(response);
         }
 


### PR DESCRIPTION
DownloadFile method did not throw an exception, instead it just downloaded an unexpected file with api error message as content so calling method assumes a success on downloaded file.
Modified to throw an exception based on existence of X-Mashery-Error-Code response header.

Probably a better way to do this but it works for us.