### PR TITLE
move LastModifed up to parent FolderMetadata

### DIFF
--- a/Egnyte.Api.Tests/Files/ListFileOrFolderTests.cs
+++ b/Egnyte.Api.Tests/Files/ListFileOrFolderTests.cs
@@ -15,6 +15,7 @@
         private const string ListFolderResponse = @"
             {    
             ""name"": ""Documents"",
+            ""lastModified"": ""1467908109000"",
             ""count"": 1,
             ""offset"": 2,
             ""path"": ""/Shared/Documents"",
@@ -42,6 +43,7 @@
             ""folders"":
                 [{
                     ""name"": ""Test"",
+                    ""lastModified"": ""1467908109000"",
                     ""path"": ""/Shared/Documents/Test"",
                     ""folder_id"": ""6a1c7f21-874e-44d0-9360-ca09eacf8553"",
                     ""is_folder"": true,
@@ -50,6 +52,7 @@
                 },
                 {
                     ""name"": ""Articles"",
+                    ""lastModified"": ""1467908109000"",
                     ""path"": ""/Shared/Documents/Articles"",
                     ""folder_id"": ""429b22bf-a111-4f7d-8460-58223db92817"",
                     ""is_folder"": true,
@@ -119,6 +122,7 @@
 
             var folderMetadata = result.AsFolder;
             Assert.AreEqual("Documents", folderMetadata.Name);
+            Assert.AreEqual(new DateTime(2016, 7, 7, 10, 15, 9), folderMetadata.LastModified);
             Assert.AreEqual(1, folderMetadata.Count);
             Assert.AreEqual(2, folderMetadata.Offset);
             Assert.AreEqual("/Shared/Documents", folderMetadata.Path);
@@ -146,6 +150,7 @@
 
             Assert.AreEqual(2, folderMetadata.Folders.Count);
             Assert.AreEqual("Test", folderMetadata.Folders[0].Name);
+            Assert.AreEqual(new DateTime(2016, 7, 7, 10, 15, 9), folderMetadata.Folders[0].LastModified);
             Assert.AreEqual("/Shared/Documents/Test", folderMetadata.Folders[0].Path);
             Assert.AreEqual("6a1c7f21-874e-44d0-9360-ca09eacf8553", folderMetadata.Folders[0].FolderId);
             Assert.AreEqual(2, folderMetadata.Folders[0].AllowedFileLinkTypes.Length);
@@ -156,6 +161,7 @@
             Assert.AreEqual("password", folderMetadata.Folders[0].AllowedFolderLinkTypes[1]);
 
             Assert.AreEqual("Articles", folderMetadata.Folders[1].Name);
+            Assert.AreEqual(new DateTime(2016, 7, 7, 10, 15, 9), folderMetadata.Folders[1].LastModified);
             Assert.AreEqual("/Shared/Documents/Articles", folderMetadata.Folders[1].Path);
             Assert.AreEqual("429b22bf-a111-4f7d-8460-58223db92817", folderMetadata.Folders[1].FolderId);
             Assert.AreEqual(2, folderMetadata.Folders[1].AllowedFileLinkTypes.Length);

--- a/Egnyte.Api.Tests/Files/ListFileOrFolderTests.cs
+++ b/Egnyte.Api.Tests/Files/ListFileOrFolderTests.cs
@@ -1,4 +1,4 @@
-﻿namespace Egnyte.Api.Tests.Files
+namespace Egnyte.Api.Tests.Files
 {
     using System;
     using System.Net;
@@ -43,7 +43,7 @@
             ""folders"":
                 [{
                     ""name"": ""Test"",
-                    ""lastModified"": ""1467908109000"",
+                    ""lastModified"": ""1467908209000"",
                     ""path"": ""/Shared/Documents/Test"",
                     ""folder_id"": ""6a1c7f21-874e-44d0-9360-ca09eacf8553"",
                     ""is_folder"": true,
@@ -52,7 +52,7 @@
                 },
                 {
                     ""name"": ""Articles"",
-                    ""lastModified"": ""1467908109000"",
+                    ""lastModified"": ""1467908309000"",
                     ""path"": ""/Shared/Documents/Articles"",
                     ""folder_id"": ""429b22bf-a111-4f7d-8460-58223db92817"",
                     ""is_folder"": true,
@@ -122,7 +122,7 @@
 
             var folderMetadata = result.AsFolder;
             Assert.AreEqual("Documents", folderMetadata.Name);
-            Assert.AreEqual(new DateTime(2016, 7, 7, 10, 15, 9), folderMetadata.LastModified);
+            Assert.AreEqual(new DateTime(2016, 7, 7, 18, 15, 9), folderMetadata.LastModified);
             Assert.AreEqual(1, folderMetadata.Count);
             Assert.AreEqual(2, folderMetadata.Offset);
             Assert.AreEqual("/Shared/Documents", folderMetadata.Path);
@@ -150,7 +150,7 @@
 
             Assert.AreEqual(2, folderMetadata.Folders.Count);
             Assert.AreEqual("Test", folderMetadata.Folders[0].Name);
-            Assert.AreEqual(new DateTime(2016, 7, 7, 10, 15, 9), folderMetadata.Folders[0].LastModified);
+            Assert.AreEqual(new DateTime(2016, 7, 7, 18, 16, 49), folderMetadata.Folders[0].LastModified);
             Assert.AreEqual("/Shared/Documents/Test", folderMetadata.Folders[0].Path);
             Assert.AreEqual("6a1c7f21-874e-44d0-9360-ca09eacf8553", folderMetadata.Folders[0].FolderId);
             Assert.AreEqual(2, folderMetadata.Folders[0].AllowedFileLinkTypes.Length);
@@ -161,7 +161,7 @@
             Assert.AreEqual("password", folderMetadata.Folders[0].AllowedFolderLinkTypes[1]);
 
             Assert.AreEqual("Articles", folderMetadata.Folders[1].Name);
-            Assert.AreEqual(new DateTime(2016, 7, 7, 10, 15, 9), folderMetadata.Folders[1].LastModified);
+            Assert.AreEqual(new DateTime(2016, 7, 7, 18, 18, 29), folderMetadata.Folders[1].LastModified);
             Assert.AreEqual("/Shared/Documents/Articles", folderMetadata.Folders[1].Path);
             Assert.AreEqual("429b22bf-a111-4f7d-8460-58223db92817", folderMetadata.Folders[1].FolderId);
             Assert.AreEqual(2, folderMetadata.Folders[1].AllowedFileLinkTypes.Length);

--- a/Egnyte.Api/Files/FilesHelper.cs
+++ b/Egnyte.Api/Files/FilesHelper.cs
@@ -126,6 +126,7 @@
             return folders.Select(
                 f => new FolderMetadata(
                     f.Name,
+                    ConvertFromUnixTimestamp(f.LastModified),
                     f.Path,
                     f.FolderId,
                     f.AllowedFileLinkTypes,

--- a/Egnyte.Api/Files/FolderExtendedMetadata.cs
+++ b/Egnyte.Api/Files/FolderExtendedMetadata.cs
@@ -19,12 +19,11 @@
             string[] allowedFolderLinkTypes,
             List<FolderMetadata> folders,
             List<FileBasicMetadata> files)
-            : base(name, path, folderId, allowedFileLinkTypes, allowedFolderLinkTypes)
+            : base(name, lastModified, path, folderId, allowedFileLinkTypes, allowedFolderLinkTypes)
         {
             Count = count;
             Offset = offset;
             TotalCount = totalCount;
-            LastModified = lastModified;
             RestrictMoveDelete = restrictMoveDelete;
             PublicLinks = publicLinks;
             Folders = folders ?? new List<FolderMetadata>();
@@ -36,8 +35,6 @@
         public int Offset { get; private set; }
 
         public int TotalCount { get; private set; }
-
-        public DateTime LastModified { get; private set; }
 
         public bool RestrictMoveDelete { get; private set; }
 

--- a/Egnyte.Api/Files/FolderMetadata.cs
+++ b/Egnyte.Api/Files/FolderMetadata.cs
@@ -1,15 +1,19 @@
 ﻿namespace Egnyte.Api.Files
 {
+    using System;
+
     public class FolderMetadata
     {
         internal FolderMetadata(
             string name,
+            DateTime lastModified,
             string path,
             string folderId,
             string[] allowedFileLinkTypes,
             string[] allowedFolderLinkTypes)
         {
             Name = name;
+            LastModified = lastModified;
             Path = path;
             FolderId = folderId;
             AllowedFileLinkTypes = allowedFileLinkTypes ?? new string[0];
@@ -17,6 +21,8 @@
         }
 
         public string Name { get; private set; }
+
+        public DateTime LastModified { get; private set; }
 
         public string Path { get; private set; }
 

--- a/Egnyte.Api/Files/FolderMetadataResponse.cs
+++ b/Egnyte.Api/Files/FolderMetadataResponse.cs
@@ -7,6 +7,9 @@
         [JsonProperty(PropertyName = "name")]
         public string Name { get; set; }
 
+        [JsonProperty(PropertyName = "lastModified")]
+        public long LastModified { get; set; }
+
         [JsonProperty(PropertyName = "path")]
         public string Path { get; set; }
 


### PR DESCRIPTION
When calling FilesClient.ListFileOrFolder I noticed that it was not returning the last modified date for folders. 
After looking at the API docs the API does actually return last modified. 

I've updated the code to reflect this.
