### PR TITLE
Added support for updating custom metadata and pagination querystring parameters for files and folders.

### DIFF
--- a/Egnyte.Api.Tests/Egnyte.Api.Tests.csproj
+++ b/Egnyte.Api.Tests/Egnyte.Api.Tests.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Files\ListFileOrFolderTests.cs" />
     <Compile Include="Files\CopyFileOrFolderTests.cs" />
     <Compile Include="Files\MoveFileOrFolderTests.cs" />
+    <Compile Include="Files\UpdateFileOrFolderCustomMetadataTests.cs" />
     <Compile Include="Files\UpdateFolderTests.cs" />
     <Compile Include="Groups\DeleteGroupTests.cs" />
     <Compile Include="Groups\FullGroupUpdateTests.cs" />

--- a/Egnyte.Api.Tests/Files/UpdateFileOrFolderCustomMetadataTests.cs
+++ b/Egnyte.Api.Tests/Files/UpdateFileOrFolderCustomMetadataTests.cs
@@ -1,0 +1,171 @@
+﻿using Egnyte.Api.Files;
+using NUnit.Framework;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.SqlServer.Server;
+
+namespace Egnyte.Api.Tests.Files
+{
+    [TestFixture]
+    public class UpdateFileOrFolderCustomMetadataTests
+    {
+        public const string UpdateFolderCustomMetadataResponse = @"
+            {
+                ""name"":""ApiTests2"",
+                ""lastModified"":1452110610000,
+                ""path"":""/Shared/MyDocument"",
+                ""folder_id"":""b0330bd2-4290-47bc-a537-e5520dc7d320"",
+                ""folder_description"":""This is new description set up at: 2018-07-27 05:29:15"",
+                ""parent_id"":""d28cfd3b-06fa-4d9a-991a-070f71c63529"",
+                ""allow_links"":true,
+                ""is_folder"":true,
+                ""public_links"":""files"",
+                ""restrict_move_delete"":true,
+                ""allow_links"":false
+            }";
+
+        private const string UpdateFileCustomMetadataResponse = @"
+        {
+            ""uploaded"": ""1439806811000"",
+            ""checksum"": ""checksum1"",
+            ""size"": 4799,
+            ""path"": ""/Shared/Documents/report.docx"",
+            ""name"": ""report.docx"",
+            ""locked"": false,
+            ""is_folder"": false,
+            ""entry_id"": ""d1b8222a-a57e-4d36-8370-d79ad3f29ee7"",
+            ""group_id"": ""c0c01799-df8b-4859-bcb1-0fb6a80fc9ac"",
+            ""last_modified"": ""Mon, 17 Aug 2015 10:28:55 GMT"",
+            ""uploaded_by"": ""mik"",
+            ""num_versions"": 1
+        }";
+
+        [Test]
+        public async Task UpdateFileOrFolderCustomMetadata_ForFolder_ReturnsSuccess()
+        {
+            var httpHandlerMock = new HttpMessageHandlerMock();
+            var httpClient = new HttpClient(httpHandlerMock);
+
+            httpHandlerMock.SendAsyncFunc =
+                (request, cancellationToken) =>
+                Task.FromResult(
+                    new HttpResponseMessage
+                    {
+                        StatusCode = HttpStatusCode.OK,
+                        Content = new StringContent(UpdateFolderCustomMetadataResponse)
+                    });
+
+            var egnyteClient = new EgnyteClient("token", "acme", httpClient);
+            var response = await egnyteClient.Files.UpdateFileOrFolderCustomMetadata(
+                    "path",
+                    "custom attributes",
+                    new FileOrFolderCustomMetadataProperties
+                    {
+                        { "reviewed", false },
+                        { "tags", "important" }
+                    });
+
+            Assert.IsTrue(response);
+
+            var requestMessage = httpHandlerMock.GetHttpRequestMessage();
+            Assert.AreEqual(
+                "https://acme.egnyte.com/pubapi/v1/fs/ids/folder/b0330bd2-4290-47bc-a537-e5520dc7d320/properties/custom attributes",
+                requestMessage.RequestUri.ToString());
+            Assert.AreEqual(
+                "{\"reviewed\" : \"False\",\"tags\" : \"important\"}",
+                httpHandlerMock.GetRequestContentAsString());
+        }
+
+        [Test]
+        public async Task UpdateFileOrFolderCustomMetadata_ForFile_ReturnsSuccess()
+        {
+            var httpHandlerMock = new HttpMessageHandlerMock();
+            var httpClient = new HttpClient(httpHandlerMock);
+
+            httpHandlerMock.SendAsyncFunc =
+                (request, cancellationToken) =>
+                    Task.FromResult(
+                        new HttpResponseMessage
+                        {
+                            StatusCode = HttpStatusCode.OK,
+                            Content = new StringContent(UpdateFileCustomMetadataResponse)
+                        });
+
+            var egnyteClient = new EgnyteClient("token", "acme", httpClient);
+            var response = await egnyteClient.Files.UpdateFileOrFolderCustomMetadata(
+                "path",
+                "custom attributes",
+                new FileOrFolderCustomMetadataProperties
+                {
+                    { "reviewed", false },
+                    { "contentType", "application/vnd.openxmlformats-officedocument.wordprocessing" }
+                });
+
+            Assert.IsTrue(response);
+
+            var requestMessage = httpHandlerMock.GetHttpRequestMessage();
+            Assert.AreEqual(
+                "https://acme.egnyte.com/pubapi/v1/fs/ids/file/c0c01799-df8b-4859-bcb1-0fb6a80fc9ac/properties/custom attributes",
+                requestMessage.RequestUri.ToString());
+            Assert.AreEqual(
+                "{\"reviewed\" : \"False\",\"contentType\" : \"application/vnd.openxmlformats-officedocument.wordprocessing\"}",
+                httpHandlerMock.GetRequestContentAsString());
+        }
+
+        [Test]
+        public async Task UpdateFileOrFolderCustomMetadata_ThrowsException_WhenPathIsNotSpecified()
+        {
+            var httpHandlerMock = new HttpMessageHandlerMock();
+            var httpClient = new HttpClient(httpHandlerMock);
+
+            var egnyteClient = new EgnyteClient("token", "acme", httpClient);
+
+            var exception = await AssertExtensions.ThrowsAsync<ArgumentException>(
+                () => egnyteClient.Files.UpdateFileOrFolderCustomMetadata(
+                    string.Empty,
+                    "custom attributes",
+                    new FileOrFolderCustomMetadataProperties()));
+
+            Assert.IsNull(exception.InnerException);
+            Assert.True(exception.Message.Contains("path"));
+        }
+
+        [Test]
+        public async Task UpdateFileOrFolderCustomMetadata_ThrowsException_WhenSectionNameIsNotSpecified()
+        {
+            var httpHandlerMock = new HttpMessageHandlerMock();
+            var httpClient = new HttpClient(httpHandlerMock);
+
+            var egnyteClient = new EgnyteClient("token", "acme", httpClient);
+
+            var exception = await AssertExtensions.ThrowsAsync<ArgumentException>(
+                () => egnyteClient.Files.UpdateFileOrFolderCustomMetadata(
+                    "path",
+                    string.Empty,
+                    new FileOrFolderCustomMetadataProperties()));
+
+            Assert.IsNull(exception.InnerException);
+            Assert.True(exception.Message.Contains("sectionName"));
+        }
+
+        [Test]
+        public async Task UpdateFileOrFolderCustomMetadata_ThrowsException_WhenPropertiesAreNotSpecified()
+        {
+            var httpHandlerMock = new HttpMessageHandlerMock();
+            var httpClient = new HttpClient(httpHandlerMock);
+
+            var egnyteClient = new EgnyteClient("token", "acme", httpClient);
+
+            var exception = await AssertExtensions.ThrowsAsync<ArgumentException>(
+                () => egnyteClient.Files.UpdateFileOrFolderCustomMetadata(
+                    "path",
+                    "custom attributes",
+                    new FileOrFolderCustomMetadataProperties()));
+
+            Assert.IsNull(exception.InnerException);
+            Assert.True(exception.Message.Contains("None of the custom metadata properties were provided"));
+        }
+    }
+}

--- a/Egnyte.Api/Egnyte.Api.csproj
+++ b/Egnyte.Api/Egnyte.Api.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Files\DownloadedFileAsStream.cs" />
     <Compile Include="Files\FileOrFolderBasicCustomMetadata.cs" />
     <Compile Include="Files\FileOrFolderCustomMetadataResponse.cs" />
+    <Compile Include="Files\FileOrFolderCustomMetadataProperties.cs" />
     <Compile Include="Files\FileOrFolderCustomMetadataSectionResponse.cs" />
     <Compile Include="Files\FileOrFolderCustomMetadata.cs" />
     <Compile Include="Files\FileOrFolderCustomMetadataSection.cs" />

--- a/Egnyte.Api/Files/FileOrFolderCustomMetadataProperties.cs
+++ b/Egnyte.Api/Files/FileOrFolderCustomMetadataProperties.cs
@@ -1,0 +1,8 @@
+﻿using System.Collections.Generic;
+
+namespace Egnyte.Api.Files
+{
+    public class FileOrFolderCustomMetadataProperties : Dictionary<string, object>
+    {
+    }
+}

--- a/Egnyte.Api/Files/FileOrFolderCustomMetadataSection.cs
+++ b/Egnyte.Api/Files/FileOrFolderCustomMetadataSection.cs
@@ -4,13 +4,13 @@ using Newtonsoft.Json;
 
 namespace Egnyte.Api.Files
 {
-    public class FileOrFolderCustomMetadataSection : Dictionary<string, Dictionary<string, object>>
+    public class FileOrFolderCustomMetadataSection : Dictionary<string, FileOrFolderCustomMetadataProperties>
     {
         [JsonConstructor]
         internal FileOrFolderCustomMetadataSection()
         {
         }
 
-        public Dictionary<string, object> Properties => Values.FirstOrDefault() ?? new Dictionary<string, object>();
+        public FileOrFolderCustomMetadataProperties Properties => Values.FirstOrDefault() ?? new FileOrFolderCustomMetadataProperties();
     }
 }

--- a/Egnyte.Api/Files/FilesClient.cs
+++ b/Egnyte.Api/Files/FilesClient.cs
@@ -209,14 +209,22 @@
         /// <param name="allowedLinkTypes">If true, then show allowed_file_link_types,
         /// allowed_folder_link_types fields, and allow_upload_links fields</param>
         /// <param name="listCustomMetadata">If true, the custom_metadata fields will be included</param>
+        /// <param name="count">The maximum number of items to return</param>
+        /// <param name="offset">The zero-based index from which to start returning items. This is used for paginating the folder listing</param>
+        /// <param name="sortBy">The field that should be used for sorting</param>
+        /// <param name="sortDirection">The direction of the sort</param>
         /// <returns>Metadata info about file or folder</returns>
         public async Task<FileOrFolderMetadata> ListFileOrFolder(
             string path,
             bool listContent = true,
             bool allowedLinkTypes = false,
-            bool listCustomMetadata = true)
+            bool? listCustomMetadata = null,
+            int? count = null,
+            int? offset = null,
+            string sortBy = null,
+            string sortDirection = null)
         {
-            var listFilesUri = PrepareListFileOrFolderUri(path, listContent, allowedLinkTypes, listCustomMetadata);
+            var listFilesUri = PrepareListFileOrFolderUri(path, listContent, allowedLinkTypes, listCustomMetadata, count, offset, sortBy, sortDirection);
             var httpRequest = new HttpRequestMessage(HttpMethod.Get, listFilesUri);
             var serviceHandler = new ServiceHandler<ListFileOrFolderResponse>(httpClient);
 
@@ -515,10 +523,37 @@
             return 0;
         }
 
-        Uri PrepareListFileOrFolderUri(string path, bool listContent, bool allowedLinkTypes, bool listCustomMetadata = true)
+        Uri PrepareListFileOrFolderUri(string path, bool listContent, bool allowedLinkTypes, bool? listCustomMetadata = null,
+            int? count = 0, int? offset = 0, string sortBy = null, string sortDirection = null)
         {
-            var query = "list_content=" + listContent + "&allowed_link_types=" + allowedLinkTypes + "&list_custom_metadata=" + listCustomMetadata;
-            var uriBuilder = BuildUri(FilesMethod + "/" + path, query);
+            var query = new StringBuilder("list_content=" + listContent + "&allowed_link_types=" + allowedLinkTypes);
+
+            if (listCustomMetadata != null)
+            {
+                query.Append("&list_custom_metadata=" + listCustomMetadata);
+            }
+
+            if (count != null)
+            {
+                query.Append("&count=" + count);
+            }
+
+            if (offset != null)
+            {
+                query.Append("&offset=" + offset);
+            }
+
+            if (sortBy != null)
+            {
+                query.Append("&sort_by=" + sortBy);
+            }
+
+            if (sortDirection != null)
+            {
+                query.Append("&sort_direction=" + sortDirection);
+            }
+
+            var uriBuilder = BuildUri(FilesMethod + "/" + path, query.ToString());
 
             return uriBuilder.Uri;
         }

--- a/Egnyte.Api/Files/FilesHelper.cs
+++ b/Egnyte.Api/Files/FilesHelper.cs
@@ -88,6 +88,20 @@
             return content;
         }
 
+        internal static string MapUpdateFileOrFolderCustomMetadataRequest(FileOrFolderCustomMetadataProperties properties)
+        {
+            var jsonParams = new List<string>();
+
+            foreach (var kvp in properties)
+            {
+                jsonParams.Add("\"" + kvp.Key + "\" : \"" + kvp.Value + "\"");
+            }
+
+            var content = "{" + string.Join(",", jsonParams) + "}";
+
+            return content;
+        }
+
         internal static UpdateFolderMetadata MapFolderUpdateToMetadata(UpdateFolderResponse response)
         {
             return new UpdateFolderMetadata


### PR DESCRIPTION
Added support for updating custom metadata for files and folders.
Added support for pagination related querystring parameters when listing files and folders.
Additionally, restored former behavior of not including custom metadata as part of the response unless explicitly asked for.