### PR TITLE
Fixes for issues related to getting/setting folder permissions for API V2

### DIFF
--- a/Egnyte.Api/Common/GroupOrUserPermissionsResponseV2Converter.cs
+++ b/Egnyte.Api/Common/GroupOrUserPermissionsResponseV2Converter.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using Egnyte.Api.Permissions;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Egnyte.Api.Common
+{
+    public class GroupOrUserPermissionsResponseV2Converter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return typeof(IDictionary<string, string>).IsAssignableFrom(objectType) && objectType != typeof(Dictionary<string, string>);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null)
+            {
+                return null;
+            }
+
+            var dictionary = existingValue as IDictionary<string, string> ?? new Dictionary<string, string>();
+
+            var token = JToken.Load(reader);
+            if (token.Type == JTokenType.Array)
+            {
+                foreach (var item in token)
+                    using (var subReader = item.CreateReader())
+                    {
+                        serializer.Populate(subReader, dictionary);
+                    }
+            }
+            else if (token.Type == JTokenType.Object)
+            {
+                using (var subReader = token.CreateReader())
+                {
+                    serializer.Populate(subReader, dictionary);
+                }
+            }
+
+            var permissions = new List<GroupOrUserPermissionsResponse>();
+
+            foreach (var kvp in dictionary)
+            {
+                permissions.Add(new GroupOrUserPermissionsResponse
+                {
+                    Subject = kvp.Key,
+                    Permission = kvp.Value
+                });
+            }
+
+            return permissions;
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {;
+            var permissions = value as List<GroupOrUserPermissionsResponse> ?? new List<GroupOrUserPermissionsResponse>();
+
+            var dictionary = new Dictionary<string, string>();
+            foreach (var p in permissions)
+            {
+                dictionary.Add(p.Subject, p.Permission);
+            }
+
+            serializer.Serialize(writer, dictionary);
+        }
+    }
+}

--- a/Egnyte.Api/Common/GroupOrUserPermissionsResponseV2Converter.cs
+++ b/Egnyte.Api/Common/GroupOrUserPermissionsResponseV2Converter.cs
@@ -54,7 +54,7 @@ namespace Egnyte.Api.Common
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
-        {;
+        {
             var permissions = value as List<GroupOrUserPermissionsResponse> ?? new List<GroupOrUserPermissionsResponse>();
 
             var dictionary = new Dictionary<string, string>();

--- a/Egnyte.Api/Egnyte.Api.csproj
+++ b/Egnyte.Api/Egnyte.Api.csproj
@@ -50,6 +50,7 @@
     <Compile Include="Audit\CreateLoginAuditReportResponse.cs" />
     <Compile Include="Common\BaseClient.cs" />
     <Compile Include="Common\EgnyteApiException.cs" />
+    <Compile Include="Common\GroupOrUserPermissionsResponseV2Converter.cs" />
     <Compile Include="Common\HttpResponseMessageExtensions.cs" />
     <Compile Include="Common\UnixTimeConverter.cs" />
     <Compile Include="Common\ServiceHandler.cs" />
@@ -107,6 +108,8 @@
     <Compile Include="Links\NewLink.cs" />
     <Compile Include="Links\ProtectionType.cs" />
     <Compile Include="OAuthHelper.cs" />
+    <Compile Include="Permissions\FolderPermissionsV2.cs" />
+    <Compile Include="Permissions\FolderPermissionsResponseV2.cs" />
     <Compile Include="Permissions\FolderPermissionsResponse.cs" />
     <Compile Include="Permissions\FolderPermissions.cs" />
     <Compile Include="Permissions\GroupOrUserPermissions.cs" />

--- a/Egnyte.Api/Permissions/FolderPermissionsResponseV2.cs
+++ b/Egnyte.Api/Permissions/FolderPermissionsResponseV2.cs
@@ -1,0 +1,20 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+using Egnyte.Api.Common;
+
+namespace Egnyte.Api.Permissions
+{
+    class FolderPermissionsResponseV2
+    {
+        [JsonProperty(PropertyName = "userPerms")]
+        [JsonConverter(typeof(GroupOrUserPermissionsResponseV2Converter))]
+        public List<GroupOrUserPermissionsResponse> Users { get; set; }
+
+        [JsonProperty(PropertyName = "groupPerms")]
+        [JsonConverter(typeof(GroupOrUserPermissionsResponseV2Converter))]
+        public List<GroupOrUserPermissionsResponse> Groups { get; set; }
+
+        [JsonProperty(PropertyName = "inheritsPermissions")]
+        public bool InheritsPermissions { get; set; }
+    }
+}

--- a/Egnyte.Api/Permissions/FolderPermissionsV2.cs
+++ b/Egnyte.Api/Permissions/FolderPermissionsV2.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+
+namespace Egnyte.Api.Permissions
+{
+    public class FolderPermissionsV2 : FolderPermissions
+    {
+        internal FolderPermissionsV2(
+            List<GroupOrUserPermissions> users,
+            List<GroupOrUserPermissions> groups,
+            bool inheritsPermissions) : base(users, groups)
+        {
+            InheritsPermissions = inheritsPermissions;
+        }
+
+        public bool InheritsPermissions { get; private set; }
+    }
+}


### PR DESCRIPTION
The following issues were fixed:

1.  Method **GetFolderPermissionsV2**, which was returning null for Groups and User permissions, now returns the correct information.
1.1 **InheritsPermissions** property is now returned as well.

2. Method **SetFolderPermissionsV2** now allows to enable/disable parent folder inheritance without having to specify users/groups.