### PR TITLE
Added support for passing client secret when using the Resource Owner…

### DIFF
--- a/Egnyte.Api.Tests/EgnyteClientHelperTests.cs
+++ b/Egnyte.Api.Tests/EgnyteClientHelperTests.cs
@@ -10,6 +10,10 @@
     [TestFixture]
     public class EgnyteClientHelperTests
     {
+        const string ResourceOwnerFlowRequestContent = "client_id=Client123&username=username&password=password&grant_type=password";
+
+        const string ResourceOwnerFloWithAllParametersSpecifiedRequestContent = "client_id=Client123&username=username&password=password&grant_type=password&client_secret=8WkD6YhXJDZrV7kWABQtr2bXBUY5GRTmuqBpRs4JDWHkNNhSK9";
+
         [Test]
         public async Task GetTokenFromCode_ReturnsCorrectToken()
         {
@@ -80,6 +84,63 @@
                 "username",
                 "password",
                 httpClient);
+
+            var requestMessage = httpHandlerMock.GetHttpRequestMessage();
+            Assert.AreEqual(
+                "https://acme.egnyte.com/puboauth/token",
+                requestMessage.RequestUri.ToString());
+            Assert.AreEqual(HttpMethod.Post, requestMessage.Method);
+
+            var requestContent = httpHandlerMock.GetRequestContentAsString();
+            Assert.AreEqual(ResourceOwnerFlowRequestContent, requestContent);
+
+            Assert.NotNull(tokenResult);
+            Assert.AreEqual(Token, tokenResult.AccessToken);
+            Assert.AreEqual(TokenType, tokenResult.TokenType);
+            Assert.AreEqual(TokenExpiresIn, tokenResult.ExpiresIn);
+        }
+
+        [Test]
+        public async Task GetTokenResourceOwnerFlow_WithAllParametersSpecified_ReturnsCorrectToken()
+        {
+            const string Token = "e8gdxt5ypf3pfn25a9kdzcac";
+            const string TokenType = "bearer";
+            const string TokenExpiresIn = "-1";
+
+            const string TokenResponseText =
+                @"{{
+                    'access_token':'{0}',
+                    'token_type':'{1}',
+                    'expires_in': '{2}'
+                }}";
+            var tokenResponse = string.Format(TokenResponseText, Token, TokenType, TokenExpiresIn);
+
+            var httpHandlerMock = new HttpMessageHandlerMock();
+            var httpClient = new HttpClient(httpHandlerMock);
+
+            httpHandlerMock.SendAsyncFunc = (request, cancellationToken) => Task.FromResult(
+                new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(tokenResponse)
+                });
+
+            var tokenResult = await EgnyteClientHelper.GetTokenResourceOwnerFlow(
+                "acme",
+                "Client123",
+                "username",
+                "password",
+                "8WkD6YhXJDZrV7kWABQtr2bXBUY5GRTmuqBpRs4JDWHkNNhSK9",
+                httpClient);
+
+            var requestMessage = httpHandlerMock.GetHttpRequestMessage();
+            Assert.AreEqual(
+                "https://acme.egnyte.com/puboauth/token",
+                requestMessage.RequestUri.ToString());
+            Assert.AreEqual(HttpMethod.Post, requestMessage.Method);
+
+            var requestContent = httpHandlerMock.GetRequestContentAsString();
+            Assert.AreEqual(ResourceOwnerFloWithAllParametersSpecifiedRequestContent, requestContent);
 
             Assert.NotNull(tokenResult);
             Assert.AreEqual(Token, tokenResult.AccessToken);

--- a/Egnyte.Api.Tests/OAuthHelperTests.cs
+++ b/Egnyte.Api.Tests/OAuthHelperTests.cs
@@ -108,6 +108,24 @@
         }
 
         [Test]
+        public void GetAuthorizationUriResourceOwnerFlow_WithAllParametersSpecified_ReturnsUrl_WhenCorrectParameters()
+        {
+            var uri = OAuthHelper.GetAuthorizationUriResourceOwnerFlow(
+                "acme",
+                "Client123",
+                "user123",
+                "password123",
+                "8WkD6YhXJDZrV7kWABQtr2bXBUY5GRTmuqBpRs4JDWHkNNhSK9");
+
+            Assert.AreEqual("https://acme.egnyte.com/puboauth/token", uri.BaseAddress.ToString());
+            Assert.AreEqual("Client123", uri.QueryParameters["client_id"]);
+            Assert.AreEqual("user123", uri.QueryParameters["username"]);
+            Assert.AreEqual("password123", uri.QueryParameters["password"]);
+            Assert.AreEqual("password", uri.QueryParameters["grant_type"]);
+            Assert.AreEqual("8WkD6YhXJDZrV7kWABQtr2bXBUY5GRTmuqBpRs4JDWHkNNhSK9", uri.QueryParameters["client_secret"]);
+        }
+
+        [Test]
         public void GetAuthorizationUriResourceOwnerFlow_ThrowsArgumentNullException_WhenDomainIsEmpty()
         {
             var exception = Assert.Throws<ArgumentNullException>(

--- a/Egnyte.Api/EgnyteClientHelper.cs
+++ b/Egnyte.Api/EgnyteClientHelper.cs
@@ -59,11 +59,23 @@
             }
         }
 
+        // kept to avoid breaking changes for existing dependent code
         public static async Task<TokenResponse> GetTokenResourceOwnerFlow(
             string userDomain,
             string clientId,
             string username,
             string password,
+            HttpClient httpClient = null)
+        {
+            return await GetTokenResourceOwnerFlow(userDomain, clientId, username, password, null, httpClient);
+        }
+
+        public static async Task<TokenResponse> GetTokenResourceOwnerFlow(
+            string userDomain,
+            string clientId,
+            string username,
+            string password,
+            string clientSecret,
             HttpClient httpClient = null)
         {
             var disposeClient = httpClient == null;
@@ -74,7 +86,8 @@
                     userDomain,
                     clientId,
                     username,
-                    password);
+                    password,
+                    clientSecret);
 
                 var content = new FormUrlEncodedContent(tokenRequesrUri.QueryParameters);
                 var result = await httpClient.PostAsync(tokenRequesrUri.BaseAddress, content).ConfigureAwait(false);

--- a/Egnyte.Api/OAuthHelper.cs
+++ b/Egnyte.Api/OAuthHelper.cs
@@ -137,13 +137,19 @@ namespace Egnyte.Api
         /// E.g. "cba97f3apst9eqzdr5hskggx".
         /// </param>
         /// <param name="username">This is the Egnyte username of the user on whose behalf you are acting.</param>
-        /// <param name="password">his is the Egnyte password of the user.</param>
+        /// <param name="password">This is the Egnyte password of the user.</param>
+        /// <param name="clientSecret">
+        /// This is the secret key that was provided with your key to you when you registered your application.
+        /// E.g. "8WkD6YhXJDZrV7kWABQtr2bXBUY5GRTmuqBpRs4JDWHkNNhSK9".
+        /// Required if your application key was requested after January 2015 and has a secret.
+        /// </param>
         /// <returns>Uri to get a token</returns>
         public static TokenRequestParameters GetAuthorizationUriResourceOwnerFlow(
             string userDomain,
             string clientId,
             string username,
-            string password)
+            string password,
+            string clientSecret = null)
         {
             if (string.IsNullOrWhiteSpace(userDomain))
             {
@@ -172,6 +178,11 @@ namespace Egnyte.Api
                     { "password", password },
                     { "grant_type", "password" }
                 };
+
+            if (!string.IsNullOrWhiteSpace(clientSecret))
+            {
+                queryParameters.Add("client_secret", clientSecret);
+            }
 
             return new TokenRequestParameters
                 {


### PR DESCRIPTION
According to the documentation, the client secret is required if your application key was requested after January 2015 and has a secret.

On certain scenarios if the client secret is not provided, the following error is returned by the API: Invalid client credentials were supplied.



