### PR TITLE
Add FolderDescription to ListFileOrFolder method

### DIFF
--- a/Egnyte.Api.Tests/Files/ListFileOrFolderTests.cs
+++ b/Egnyte.Api.Tests/Files/ListFileOrFolderTests.cs
@@ -23,6 +23,7 @@ namespace Egnyte.Api.Tests.Files
             ""offset"": 2,
             ""path"": ""/Shared/Documents"",
             ""folder_id"": ""f3066c91-245c-446d-85ac-bfb88196e4e8"",
+            ""folder_description"": ""folder description"",
             ""custom_metadata"": [
                 {
                     ""custom attributes"": {
@@ -171,6 +172,7 @@ namespace Egnyte.Api.Tests.Files
             Assert.AreEqual(2, folderMetadata.Offset);
             Assert.AreEqual("/Shared/Documents", folderMetadata.Path);
             Assert.AreEqual("f3066c91-245c-446d-85ac-bfb88196e4e8", folderMetadata.FolderId);
+            Assert.AreEqual("folder description", folderMetadata.FolderDescription);
             Assert.AreEqual(18, folderMetadata.TotalCount);
             Assert.AreEqual("files_folders", folderMetadata.PublicLinks);
             Assert.AreEqual(true, folderMetadata.RestrictMoveDelete);

--- a/Egnyte.Api/Files/FilesHelper.cs
+++ b/Egnyte.Api/Files/FilesHelper.cs
@@ -24,6 +24,7 @@
                         response.Offset,
                         response.Path,
                         response.FolderId,
+                        response.FolderDescription,
                         response.TotalCount,
                         ConvertFromUnixTimestamp(response.LastModifiedFolder),
                         response.RestrictMoveDelete,

--- a/Egnyte.Api/Files/FolderExtendedMetadata.cs
+++ b/Egnyte.Api/Files/FolderExtendedMetadata.cs
@@ -11,6 +11,7 @@
             int offset,
             string path,
             string folderId,
+            string folderDescription,
             int totalCount,
             DateTime lastModified,
             bool restrictMoveDelete,
@@ -24,6 +25,7 @@
         {
             Count = count;
             Offset = offset;
+            FolderDescription = folderDescription;
             TotalCount = totalCount;
             RestrictMoveDelete = restrictMoveDelete;
             PublicLinks = publicLinks;
@@ -34,6 +36,8 @@
         public int Count { get; private set; }
 
         public int Offset { get; private set; }
+
+        public string FolderDescription { get; private set; }
 
         public int TotalCount { get; private set; }
 

--- a/Egnyte.Api/Files/ListFileOrFolderResponse.cs
+++ b/Egnyte.Api/Files/ListFileOrFolderResponse.cs
@@ -29,6 +29,9 @@ namespace Egnyte.Api.Files
         [JsonProperty(PropertyName = "folder_id")]
         public string FolderId { get; set; }
 
+        [JsonProperty(PropertyName = "folder_description")]
+        public string FolderDescription { get; set; }
+
         [JsonProperty(PropertyName = "total_count")]
         public int TotalCount { get; set; }
 


### PR DESCRIPTION
Added support for a `FolderDescription` returned as part of `ListFileOrFolder`.

Please note that this field is not present in the server response in case a folder does not have a description, thus it will result in `FolderDescription = null`.

Example response from cloud:
```
{
    "name": "somePath",
    "lastModified": 1739892515000,
    "uploaded": 1739892497070,
    "path": "/Shared/somePath",
    "folder_id": "aa941e30-fc81-481b-9c5a-03f83181e595",
    "folder_description": "some_desc",
    "custom_metadata": [],
    "parent_id": "1544c9f0-c5df-4cce-94f5-f3c0c4353c43",
    "allow_links": true,
    "public_links": "files_folders",
    "restrict_move_delete": true,
    "is_folder": true
}
```