### PR TITLE
Fix issue #31: make ProjectFolders methods (CreateProjectFromTemplate, UpdateProject, MarkFolderAsProject) work correctly

### DIFF
--- a/Egnyte.Api.Tests/ProjectFolders/UpdateProjectTests.cs
+++ b/Egnyte.Api.Tests/ProjectFolders/UpdateProjectTests.cs
@@ -85,7 +85,7 @@ namespace Egnyte.Api.Tests.ProjectFolders
         }
 
         [Test]
-        public async Task UpdateProject_WhenProjectIdIsEmpty_ThrowsArgumentNullException()
+        public async Task UpdateProject_WhenIdIsEmpty_ThrowsArgumentNullException()
         {
             var httpClient = new HttpClient(new HttpMessageHandlerMock());
             var egnyteClient = new EgnyteClient("token", "acme", httpClient);
@@ -93,12 +93,37 @@ namespace Egnyte.Api.Tests.ProjectFolders
             var exception = await AssertExtensions.ThrowsAsync<ArgumentNullException>(
                 () => egnyteClient.ProjectFolders.UpdateProject(
                     name: "Acme Widgets HQ",
-                    id: "P123",
+                    id: string.Empty,
                     status: "pending",
-                    projectId: string.Empty));
+                    projectId: "ABC123"));
 
-            Assert.IsTrue(exception.Message.Contains("projectId"));
+            Assert.IsTrue(exception.Message.Contains("id"));
             Assert.IsNull(exception.InnerException);
+        }
+
+        [Test]
+        public async Task UpdateProject_WhenProjectIdIsEmpty_ReturnsSuccess()
+        {
+            var httpHandlerMock = new HttpMessageHandlerMock();
+            var httpClient = new HttpClient(httpHandlerMock);
+
+            httpHandlerMock.SendAsyncFunc =
+                (request, cancellationToken) =>
+                    Task.FromResult(
+                        new HttpResponseMessage
+                        {
+                            StatusCode = HttpStatusCode.OK,
+                            Content = new StringContent(string.Empty)
+                        });
+
+            var egnyteClient = new EgnyteClient("token", "acme", httpClient);
+            var updateProjectResponse = await egnyteClient.ProjectFolders.UpdateProject(
+                name: "Acme Widgets HQ",
+                id: "P123",
+                status: "pending",
+                projectId: string.Empty);
+
+            Assert.IsTrue(updateProjectResponse);
         }
     }
 }

--- a/Egnyte.Api/ProjectFolders/ProjectFoldersClient.cs
+++ b/Egnyte.Api/ProjectFolders/ProjectFoldersClient.cs
@@ -275,9 +275,9 @@ namespace Egnyte.Api.ProjectFolders
                 throw new ArgumentNullException(nameof(name));
             }
 
-            if (string.IsNullOrWhiteSpace(projectId))
+            if (string.IsNullOrWhiteSpace(id))//id is a required field but projectId is an optional field.
             {
-                throw new ArgumentNullException(nameof(projectId));
+                throw new ArgumentNullException(nameof(id));
             }
 
             if (string.IsNullOrWhiteSpace(status))
@@ -376,56 +376,73 @@ namespace Egnyte.Api.ProjectFolders
             {
                 builder.Append("\"name\" : \"" + name + "\",");
             }
-            if (!string.IsNullOrWhiteSpace(status))
+            if (status != null)//if (!string.IsNullOrWhiteSpace(status))//should be able to clear the field
             {
                 builder.Append("\"status\" : \"" + status + "\",");
             }
-            if (!string.IsNullOrWhiteSpace(description))
+            if (description != null)//if (!string.IsNullOrWhiteSpace(description))//should be able to clear the field
             {
                 builder.Append("\"description\" : \"" + description + "\",");
             }
             if (!string.IsNullOrWhiteSpace(projectId))
             {
-                builder.Append("\"id\" : \"" + projectId + "\",");
+                builder.Append("\"projectId\" : \"" + projectId + "\",");//this was the id which should have been a guid identifier and is already mapped from part of the URL
             }
-            if (!string.IsNullOrWhiteSpace(customerName))
+            if (customerName != null)//if (!string.IsNullOrWhiteSpace(customerName))//should be able to clear the field
             {
                 builder.Append("\"customerName\" : \"" + customerName + "\",");
             }
             if (location != null)
             {
-                if (!string.IsNullOrWhiteSpace(location.StreetAddress1))
+                builder.Append("\"location\" : {");
+                if (location.StreetAddress1 != null)//if (!string.IsNullOrWhiteSpace(location.StreetAddress1))
                 {
-                    builder.Append("\"location.streetAddress1\" : \"" + location.StreetAddress1 + "\",");
+                    builder.Append("\"streetAddress1\" : \"" + location.StreetAddress1 + "\",");
                 }
-                if (!string.IsNullOrWhiteSpace(location.StreetAddress2))
+                if (location.StreetAddress2 != null)//if (!string.IsNullOrWhiteSpace(location.StreetAddress2))
                 {
-                    builder.Append("\"location.streetAddress2\" : \"" + location.StreetAddress2 + "\",");
+                    builder.Append("\"streetAddress2\" : \"" + location.StreetAddress2 + "\",");
                 }
-                if (!string.IsNullOrWhiteSpace(location.City))
+                if (location.City != null)//if (!string.IsNullOrWhiteSpace(location.City))
                 {
-                    builder.Append("\"location.city\" : \"" + location.City + "\",");
+                    builder.Append("\"city\" : \"" + location.City + "\",");
                 }
-                if (!string.IsNullOrWhiteSpace(location.State))
+                if (location.State != null)//if (!string.IsNullOrWhiteSpace(location.State))
                 {
-                    builder.Append("\"location.state\" : \"" + location.State + "\",");
+                    builder.Append("\"state\" : \"" + location.State + "\",");
                 }
-                if (!string.IsNullOrWhiteSpace(location.PostalCode))
+                if (location.PostalCode != null)//if (!string.IsNullOrWhiteSpace(location.PostalCode))
                 {
-                    builder.Append("\"location.postalCode\" : \"" + location.PostalCode + "\",");
+                    builder.Append("\"postalCode\" : \"" + location.PostalCode + "\",");
                 }
-                if (!string.IsNullOrWhiteSpace(location.Country))
+                if (location.Country != null)//if (!string.IsNullOrWhiteSpace(location.Country))
                 {
-                    builder.Append("\"location.country\" : \"" + location.Country + "\",");
+                    builder.Append("\"country\" : \"" + location.Country + "\",");
                 }
+                if(builder[builder.Length-1]==',')builder.Length -= 1;
+                builder.Append("},");
             }
             if (startDate.HasValue)
             {
-                builder.Append("\"startDate\" : \"" + startDate.Value.ToUniversalTime().ToString("yyyy-MM-ddThh:mm:ss.000+0000") + "\",");
+                if (startDate.Value != DateTime.MinValue)
+                {
+                    builder.Append("\"startDate\" : \"" + startDate.Value.ToUniversalTime().ToString("yyyy-MM-dd") + "\",");
+                }
+                else
+                {
+                    builder.Append("\"startDate\" : \"\",");//sending a blank value doesn't seem to clear the information through Egnyte's API so this change is ineffective but may be supported in the future.
+                }
+               
             }
             if (completionDate.HasValue)
             {
-                builder.Append("\"completionDate\" : \"" + completionDate.Value.ToUniversalTime().ToString("yyyy-MM-ddThh:mm:ss.000+0000") + "\",");
+                if (completionDate.Value != DateTime.MinValue)
+                {                     builder.Append("\"completionDate\" : \"" + completionDate.Value.ToUniversalTime().ToString("yyyy-MM-dd") + "\",");
+                }
+                else
+                {
+                    builder.Append("\"completionDate\" : \"\",");//sending a blank value doesn't seem to clear the information through Egnyte's API so this change is ineffective but may be supported in the future.
+                }
             }
             builder.Length -= 1;
             builder.Append("}");
@@ -460,11 +477,11 @@ namespace Egnyte.Api.ProjectFolders
             }
             if (startDate.HasValue)
             {
-                builder.Append("\"startDate\" : \"" + startDate.Value.ToUniversalTime().ToString("yyyy-MM-ddThh:mm:ss.000+0000") + "\",");
+                builder.Append("\"startDate\" : \"" + startDate.Value.ToUniversalTime().ToString("yyyy-MM-dd") + "\",");//documentation and testing indicate that only a Date value is supported
             }
             if (completionDate.HasValue)
             {
-                builder.Append("\"completionDate\" : \"" + completionDate.Value.ToUniversalTime().ToString("yyyy-MM-ddThh:mm:ss.000+0000") + "\",");
+                builder.Append("\"completionDate\" : \"" + completionDate.Value.ToUniversalTime().ToString("yyyy-MM-dd") + "\",");//documentation and testing indicate that only a Date value is supported
             }
             builder.Length -= 1;
             builder.Append("}");

--- a/Egnyte.Api/ProjectFolders/ProjectFoldersClient.cs
+++ b/Egnyte.Api/ProjectFolders/ProjectFoldersClient.cs
@@ -376,46 +376,46 @@ namespace Egnyte.Api.ProjectFolders
             {
                 builder.Append("\"name\" : \"" + name + "\",");
             }
-            if (status != null)//if (!string.IsNullOrWhiteSpace(status))//should be able to clear the field
+            if (status != null)
             {
                 builder.Append("\"status\" : \"" + status + "\",");
             }
-            if (description != null)//if (!string.IsNullOrWhiteSpace(description))//should be able to clear the field
+            if (description != null)
             {
                 builder.Append("\"description\" : \"" + description + "\",");
             }
             if (!string.IsNullOrWhiteSpace(projectId))
             {
-                builder.Append("\"projectId\" : \"" + projectId + "\",");//this was the id which should have been a guid identifier and is already mapped from part of the URL
+                builder.Append("\"projectId\" : \"" + projectId + "\","); // this was the id which should have been a guid identifier and is already mapped from part of the URL
             }
-            if (customerName != null)//if (!string.IsNullOrWhiteSpace(customerName))//should be able to clear the field
+            if (customerName != null)
             {
                 builder.Append("\"customerName\" : \"" + customerName + "\",");
             }
             if (location != null)
             {
                 builder.Append("\"location\" : {");
-                if (location.StreetAddress1 != null)//if (!string.IsNullOrWhiteSpace(location.StreetAddress1))
+                if (location.StreetAddress1 != null)
                 {
                     builder.Append("\"streetAddress1\" : \"" + location.StreetAddress1 + "\",");
                 }
-                if (location.StreetAddress2 != null)//if (!string.IsNullOrWhiteSpace(location.StreetAddress2))
+                if (location.StreetAddress2 != null)
                 {
                     builder.Append("\"streetAddress2\" : \"" + location.StreetAddress2 + "\",");
                 }
-                if (location.City != null)//if (!string.IsNullOrWhiteSpace(location.City))
+                if (location.City != null)
                 {
                     builder.Append("\"city\" : \"" + location.City + "\",");
                 }
-                if (location.State != null)//if (!string.IsNullOrWhiteSpace(location.State))
+                if (location.State != null)
                 {
                     builder.Append("\"state\" : \"" + location.State + "\",");
                 }
-                if (location.PostalCode != null)//if (!string.IsNullOrWhiteSpace(location.PostalCode))
+                if (location.PostalCode != null)
                 {
                     builder.Append("\"postalCode\" : \"" + location.PostalCode + "\",");
                 }
-                if (location.Country != null)//if (!string.IsNullOrWhiteSpace(location.Country))
+                if (location.Country != null)
                 {
                     builder.Append("\"country\" : \"" + location.Country + "\",");
                 }
@@ -437,7 +437,8 @@ namespace Egnyte.Api.ProjectFolders
             if (completionDate.HasValue)
             {
                 if (completionDate.Value != DateTime.MinValue)
-                {                     builder.Append("\"completionDate\" : \"" + completionDate.Value.ToUniversalTime().ToString("yyyy-MM-dd") + "\",");
+                {
+                    builder.Append("\"completionDate\" : \"" + completionDate.Value.ToUniversalTime().ToString("yyyy-MM-dd") + "\",");
                 }
                 else
                 {


### PR DESCRIPTION
## Summary

Fixes the `ProjectFoldersClient` so that `CreateProjectFromTemplate`, `UpdateProject`, and `MarkFolderAsProject` behave correctly (issue #31).

This is a clean, rebased version of the single meaningful change from #38. The original PR was branched from a very old commit and carried 55 commits of duplicate history that `master` already contains under different hashes, which inflated the diff and produced merge conflicts. This branch contains **only** the actual fix, cherry-picked on top of current `master`.